### PR TITLE
Fix <Tooltip>s not working after initial navigation

### DIFF
--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useRef } from "react";
 import PropTypes from "prop-types";
 import { addMissingUnit, isClient } from "utility";
 
 import Header from "components/Header";
 import Footer from "components/Footer";
+import Tooltip from "components/Tooltip";
 
 import "scss/main.scss";
 
@@ -14,9 +15,10 @@ if (isClient) {
 }
 
 function Layout({ children, className, headerProps, footerProps, navOffset }) {
+  const portalRef = useRef(null);
   return (
-    <>
-      <div id="tooltip-portal" />
+    <Tooltip.PortalRefContext.Provider value={portalRef}>
+      <div id="tooltip-portal" ref={portalRef} />
       <Header {...headerProps} />
       <main
         style={{ marginTop: addMissingUnit(navOffset) }}
@@ -24,7 +26,7 @@ function Layout({ children, className, headerProps, footerProps, navOffset }) {
         className={className}
       />
       <Footer {...footerProps} />
-    </>
+    </Tooltip.PortalRefContext.Provider>
   );
 }
 

--- a/src/components/Tooltip/index.jsx
+++ b/src/components/Tooltip/index.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext, createContext } from "react";
 import PropTypes from "prop-types";
 import { addMissingUnit } from "utility";
 
@@ -20,12 +20,13 @@ function Tooltip({
   delay,
   ...rest
 }) {
+  const portalRef = useContext(Tooltip.PortalRefContext);
   return (
     <OverlayTrigger
       trigger={toggle ? "click" : undefined}
       placement={top ? "top" : bottom ? "bottom" : left ? "left" : "right"}
       children={children}
-      container={() => document.getElementById("tooltip-portal")}
+      container={() => portalRef.current}
       popperConfig={{
         modifiers: {
           preventOverflow: {
@@ -82,3 +83,9 @@ Tooltip.defaultProps = {
 };
 
 Tooltip.displayName = "Tooltip";
+
+// ? ==========
+// ? Context
+// ? ==========
+
+Tooltip.PortalRefContext = createContext({ current: null });

--- a/src/scss/_extend.scss
+++ b/src/scss/_extend.scss
@@ -9,7 +9,7 @@
     font-weight: 600;
     letter-spacing: 1px;
     cursor: pointer !important;
-    color: inherit;
+    color: inherit !important;
     border-bottom: none !important;
 
     &::after {


### PR DESCRIPTION
Uses React Context API to pass ref to custom tooltip portal (from `<Layout>`) down to any `<Tooltip>` components that need it.